### PR TITLE
fix(datetime): remove double target timezone shift

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Sort event slots chronologically in LIST and MULTILIST display types (previously rendered in API-returned order)
+- Fix ~2h timezone shift in booking widget caused by double-applied target offset in `convertSourceDateTimeToTargetDateTime` (visible when display timezone ≠ browser timezone)
+
+### Changed
+
+- Drop dead `sourceTimeZone` parameter from time-format helpers and all call sites (API returns real UTC; only target timezone is needed)
+- Simplify display-type dispatch in `getDatesValue`, chip-label logic in `BookService`, and `handleSubmit` in `RescheduleService`
 
 ## [1.2.8] - 2026-02-27
 

--- a/jest.config.cjs
+++ b/jest.config.cjs
@@ -2,7 +2,7 @@ module.exports = {
     preset: 'ts-jest',
     testEnvironment: 'node',
     transform: {
-      '^.+\\.ts?$': 'ts-jest',
+      '^.+\\.tsx?$': 'ts-jest',
     },
     transformIgnorePatterns: ['<rootDir>/node_modules/'],
     moduleDirectories: ['node_modules', 'src'],

--- a/src/components/EventsMultiDatesWrapper/EventsMultiDatesWrapper.tsx
+++ b/src/components/EventsMultiDatesWrapper/EventsMultiDatesWrapper.tsx
@@ -4,7 +4,7 @@ import { useLocale } from "helpers/hooks/useLocale";
 import { Service } from "models/service";
 import { Slot } from "models/slots";
 import { useTranslation } from "react-i18next";
-import { useBookingStore, useUiStore } from "state/stores";
+import { useUiStore } from "state/stores";
 import styled from "styled-components";
 import { EventMultiSlot } from "./components";
 
@@ -26,7 +26,6 @@ interface Props {
 export const EventsMultiDatesWrapper: React.FC<Props> = ({ handlers, additionalData }) => {
   const { t } = useTranslation();
   const timeZone = useUiStore((state) => state.timeZone);
-  const service = useBookingStore((state) => state.service)!;
   const locale = useLocale();
 
   useEffect(() => {
@@ -45,7 +44,6 @@ export const EventsMultiDatesWrapper: React.FC<Props> = ({ handlers, additionalD
   return (
     <EventMultiSlot
       targetTimeZone={timeZone}
-      sourceTimeZone={service.project.localTimeZone}
       locale={locale}
       service={additionalData.service}
       slots={additionalData.slots}

--- a/src/components/EventsMultiDatesWrapper/components/EventMultiSlot.tsx
+++ b/src/components/EventsMultiDatesWrapper/components/EventMultiSlot.tsx
@@ -60,13 +60,12 @@ const EventSlotButton = styled.button<EventSlotButtonProps>`
 
 interface Props {
   targetTimeZone: string;
-  sourceTimeZone: string;
   locale: Locale;
   service: Service;
   slots: Slot[];
 }
 
-export function EventMultiSlot({ targetTimeZone, sourceTimeZone, locale, service, slots }: Props) {
+export function EventMultiSlot({ targetTimeZone, locale, service, slots }: Props) {
   const hoursSystem = useUiStore((state) => state.hoursSystem);
   const is12HoursSystem = hoursSystem === HOURS_SYSTEMS.h12;
   const { t } = useTranslation();
@@ -78,12 +77,11 @@ export function EventMultiSlot({ targetTimeZone, sourceTimeZone, locale, service
         dateTimeFrom,
         dateTimeTo,
         targetTimeZone,
-        sourceTimeZone,
         locale,
         is12HoursSystem,
       }),
     // eslint-disable-next-line react-hooks/exhaustive-deps
-    [targetTimeZone, sourceTimeZone, locale, service?.viewConfig?.list?.showTime, is12HoursSystem],
+    [targetTimeZone, locale, service?.viewConfig?.list?.showTime, is12HoursSystem],
   );
 
   const showQuantity = service?.viewConfig?.multiList?.quantity;

--- a/src/components/EventsWrapper/EventsWrapper.tsx
+++ b/src/components/EventsWrapper/EventsWrapper.tsx
@@ -4,7 +4,7 @@ import { useLocale } from "helpers/hooks/useLocale";
 import { Service } from "models/service";
 import { Slot } from "models/slots";
 import { useTranslation } from "react-i18next";
-import { useBookingStore, useUiStore } from "state/stores";
+import { useUiStore } from "state/stores";
 import styled from "styled-components";
 import { EventSlot } from "./components";
 
@@ -26,7 +26,6 @@ interface Props {
 export const EventsWrapper: React.FC<Props> = ({ handlers, additionalData }) => {
   const { t } = useTranslation();
   const timeZone = useUiStore((state) => state.timeZone);
-  const service = useBookingStore((state) => state.service)!;
   const locale = useLocale();
 
   useEffect(() => {
@@ -44,25 +43,26 @@ export const EventsWrapper: React.FC<Props> = ({ handlers, additionalData }) => 
     );
   }
 
+  const availableSlots = additionalData.slots
+    .filter((slot) => slot.quantity > 0)
+    .slice()
+    .sort((a, b) => a.dateTimeFrom.localeCompare(b.dateTimeFrom));
+
   return (
     <>
-      {[...additionalData.slots]
-        .sort((a, b) => a.dateTimeFrom.localeCompare(b.dateTimeFrom))
-        .filter((slot: Slot) => slot.quantity > 0)
-        .map((slot: Slot) => (
-          <EventSlot
-            key={slot.slotId}
-            id={slot.slotId}
-            dateTimeFrom={slot.dateTimeFrom}
-            dateTimeTo={slot.dateTimeTo}
-            quantity={slot.quantity}
-            handlers={handlers}
-            targetTimeZone={timeZone}
-            sourceTimeZone={service.project.localTimeZone}
-            locale={locale}
-            service={additionalData.service}
-          />
-        ))}
+      {availableSlots.map((slot) => (
+        <EventSlot
+          key={slot.slotId}
+          id={slot.slotId}
+          dateTimeFrom={slot.dateTimeFrom}
+          dateTimeTo={slot.dateTimeTo}
+          quantity={slot.quantity}
+          handlers={handlers}
+          targetTimeZone={timeZone}
+          locale={locale}
+          service={additionalData.service}
+        />
+      ))}
     </>
   );
 };

--- a/src/components/EventsWrapper/components/EventSlot.tsx
+++ b/src/components/EventsWrapper/components/EventSlot.tsx
@@ -66,7 +66,6 @@ interface Props {
     setSelectedSlots: (slotIds: string[]) => void;
   };
   targetTimeZone: string;
-  sourceTimeZone: string;
   locale: Locale;
   service: Service;
 }
@@ -78,7 +77,6 @@ export function EventSlot({
   quantity,
   handlers,
   targetTimeZone,
-  sourceTimeZone,
   locale,
   service,
 }: Props) {
@@ -117,20 +115,11 @@ export function EventSlot({
         dateTimeFrom,
         dateTimeTo,
         targetTimeZone,
-        sourceTimeZone,
         locale,
         is12HoursSystem,
       }),
     // eslint-disable-next-line react-hooks/exhaustive-deps
-    [
-      dateTimeFrom,
-      dateTimeTo,
-      targetTimeZone,
-      sourceTimeZone,
-      locale,
-      service?.viewConfig?.list?.showTime,
-      is12HoursSystem,
-    ],
+    [dateTimeFrom, dateTimeTo, targetTimeZone, locale, service?.viewConfig?.list?.showTime, is12HoursSystem],
   );
 
   const showQuantity = service?.viewConfig?.list?.quantity;

--- a/src/features/booking/components/BookingCard/BookingCardSummary/BookingCardTitle.tsx
+++ b/src/features/booking/components/BookingCard/BookingCardSummary/BookingCardTitle.tsx
@@ -77,7 +77,6 @@ function BookingCardTitle({
               dateTimeFrom: slot.dateTimeFrom,
               dateTimeTo: slot.dateTimeTo,
               targetTimeZone: timeZone,
-              sourceTimeZone: service.project.localTimeZone,
               locale,
               is12HoursSystem,
             })} (${timeZone.replace("_", " ")})`}

--- a/src/features/confirmation/components/ConfirmContent/DeleteBooking.tsx
+++ b/src/features/confirmation/components/ConfirmContent/DeleteBooking.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo } from "react";
+import React from "react";
 import { Typography } from "components/Typography";
 import { Box } from "components/layout/Box";
 import { Column } from "components/layout/Column";
@@ -23,7 +23,7 @@ const DeleteBooking = () => {
   const service = useBookingStore((state) => state.service)!;
   const timeZone = useUiStore((state) => state.timeZone);
   const hoursSystem = useUiStore((state) => state.hoursSystem);
-  const is12HoursSystem = useMemo(() => hoursSystem === HOURS_SYSTEMS.h12, [hoursSystem]);
+  const is12HoursSystem = hoursSystem === HOURS_SYSTEMS.h12;
 
   return (
     <Column $ai="flex-start">
@@ -49,7 +49,6 @@ const DeleteBooking = () => {
               dateTimeFrom: booking.dateTimeFrom,
               dateTimeTo: booking.dateTimeTo,
               targetTimeZone: timeZone,
-              sourceTimeZone: service.project.localTimeZone,
               locale,
               is12HoursSystem,
             })}

--- a/src/features/service/components/Service/BookService/BookService.tsx
+++ b/src/features/service/components/Service/BookService/BookService.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useMemo } from "react";
+import React, { useCallback } from "react";
 import { Button } from "components/Button";
 import { Card } from "components/Card";
 import { Typography } from "components/Typography";
@@ -124,7 +124,7 @@ const BookService = () => {
   const uploadState = useUploadStore((state) => state.uploadAttachments);
   const timeZone = useUiStore((state) => state.timeZone);
   const hoursSystem = useUiStore((state) => state.hoursSystem);
-  const is12HoursSystem = useMemo(() => hoursSystem === HOURS_SYSTEMS.h12, [hoursSystem]);
+  const is12HoursSystem = hoursSystem === HOURS_SYSTEMS.h12;
   const setSelectedSlots = useBookingStore((state) => state.setSelectedSlots);
   const slots = useBookingStore((state) => state.slots)!;
   const locations = useProjectStore((state) => state.location);
@@ -142,7 +142,6 @@ const BookService = () => {
     ? convertSourceDateTimeToTargetDateTime({
         date: selectedSlot.dateTimeFrom,
         targetTimeZone: timeZone,
-        sourceTimeZone: service.project.localTimeZone,
         dateFormat,
         locale,
       })
@@ -152,7 +151,6 @@ const BookService = () => {
     ? convertSourceDateTimeToTargetDateTime({
         date: selectedDateRangeValue.dateTimeFrom,
         targetTimeZone: timeZone,
-        sourceTimeZone: service.project.localTimeZone,
         dateFormat: "d MMM",
         locale,
       })
@@ -162,26 +160,26 @@ const BookService = () => {
     ? convertSourceDateTimeToTargetDateTime({
         date: selectedDateRangeValue.dateTimeTo,
         targetTimeZone: timeZone,
-        sourceTimeZone: service.project.localTimeZone,
         dateFormat: "d MMM",
         locale,
       })
     : null;
 
-  const chipLabel = (() => {
-    if (serviceType === BOOKING_FORM_TYPES.CALENDAR && formattedRangeFrom && formattedRangeTo) {
-      return `${formattedRangeFrom} – ${formattedRangeTo}`;
+  function getChipLabel(): string | null {
+    switch (serviceType) {
+      case BOOKING_FORM_TYPES.CALENDAR:
+        if (formattedRangeFrom && formattedRangeTo) return `${formattedRangeFrom} – ${formattedRangeTo}`;
+        return null;
+      case BOOKING_FORM_TYPES.DAYS:
+      case BOOKING_FORM_TYPES.LIST:
+      case BOOKING_FORM_TYPES.MULTILIST:
+        return formattedDate || null;
+      default:
+        return null;
     }
-    if (
-      (serviceType === BOOKING_FORM_TYPES.DAYS ||
-        serviceType === BOOKING_FORM_TYPES.LIST ||
-        serviceType === BOOKING_FORM_TYPES.MULTILIST) &&
-      formattedDate
-    ) {
-      return formattedDate;
-    }
-    return null;
-  })();
+  }
+
+  const chipLabel = getChipLabel();
 
   const checkDisableButton = useCallback(() => {
     const disabledForSlots = !selectedSlotsValue.length || loading || isUploading;

--- a/src/features/service/components/Service/RescheduleService/RescheduleService.tsx
+++ b/src/features/service/components/Service/RescheduleService/RescheduleService.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useMemo } from "react";
+import React, { useCallback } from "react";
 import { Button } from "components/Button";
 import { Card } from "components/Card";
 import { Typography } from "components/Typography";
@@ -57,7 +57,7 @@ const RescheduleService = () => {
   const isEventType = serviceType === BOOKING_FORM_TYPES.LIST || serviceType === BOOKING_FORM_TYPES.MULTILIST;
 
   const hoursSystem = useUiStore((state) => state.hoursSystem);
-  const is12HoursSystem = useMemo(() => hoursSystem === HOURS_SYSTEMS.h12, [hoursSystem]);
+  const is12HoursSystem = hoursSystem === HOURS_SYSTEMS.h12;
   const dateFormat = is12HoursSystem ? "iiii dd MMM, h:mm a" : "iiii dd MMM, H:mm";
 
   const selectedSlot = slots.find((slot) => slot.slotId === selectedSlotsValue[0])!;
@@ -65,7 +65,6 @@ const RescheduleService = () => {
     ? convertSourceDateTimeToTargetDateTime({
         date: selectedSlot.dateTimeFrom,
         targetTimeZone: timeZone,
-        sourceTimeZone: service.project.localTimeZone,
         dateFormat,
         locale,
       })
@@ -76,37 +75,20 @@ const RescheduleService = () => {
     convertSourceDateTimeToTargetDateTime({
       date: bookingValue.dateTimeFrom,
       targetTimeZone: timeZone,
-      sourceTimeZone: service.project.localTimeZone,
       dateFormat,
       locale,
     });
 
   const handleSubmit = () => {
-    if (isSlotType) {
-      if (!selectedSlotsValue.length || bookingValue?.bookingId === undefined) return;
-      rescheduleBookingMutation({
-        variables: {
-          bookingId: bookingValue.bookingId,
-          slots: selectedSlotsValue,
-        },
-      });
-    } else if (isDateRangeType) {
-      if (!selectedSlotsValue.length || bookingValue?.bookingId === undefined) return;
-      rescheduleBookingMutation({
-        variables: {
-          bookingId: bookingValue.bookingId,
-          slots: selectedSlotsValue,
-        },
-      });
-    } else if (isEventType) {
-      if (!selectedSlotsValue.length || bookingValue?.bookingId === undefined) return;
-      rescheduleBookingMutation({
-        variables: {
-          bookingId: bookingValue.bookingId,
-          slots: selectedSlotsValue,
-        },
-      });
-    }
+    if (!isSlotType && !isDateRangeType && !isEventType) return;
+    if (!selectedSlotsValue.length || bookingValue?.bookingId === undefined) return;
+
+    rescheduleBookingMutation({
+      variables: {
+        bookingId: bookingValue.bookingId,
+        slots: selectedSlotsValue,
+      },
+    });
   };
 
   const checkDisableButton = useCallback(() => {

--- a/src/features/service/components/Service/ServiceDateTime/ServiceCalendar/TimeSlot.tsx
+++ b/src/features/service/components/Service/ServiceDateTime/ServiceCalendar/TimeSlot.tsx
@@ -3,7 +3,6 @@ import { Typography } from "components/Typography";
 import { Column } from "components/layout/Column";
 import { useSlotsViewConfiguration } from "features/service/hooks/useSlotsViewConfiguration";
 import { convertSourceDateTimeToTargetDateTimeWithHoursSystem } from "helpers/timeFormat";
-import { Service } from "models/service";
 import { Slot } from "models/slots";
 import { TimeSlotButtonType } from "models/theme";
 import { useTimeSlotByDate } from "state/hooks";
@@ -137,22 +136,17 @@ interface SlotContentProps {
   date: string;
   timeZone: string;
   is12HoursSystem: boolean;
-  service: Service;
   showDuration: boolean;
   showQuantity: boolean;
 }
 
-function SlotContent({ slot, date, timeZone, is12HoursSystem, service, showDuration, showQuantity }: SlotContentProps) {
-  const sourceTimeZone = service.project.localTimeZone;
-  if (!sourceTimeZone) return null;
-
+function SlotContent({ slot, date, timeZone, is12HoursSystem, showDuration, showQuantity }: SlotContentProps) {
   const unavailableClassName = slot.quantity > 0 ? "" : "unavailable-time-slot";
 
   const formatTime = (targetDate: string) =>
     convertSourceDateTimeToTargetDateTimeWithHoursSystem({
       date: targetDate,
       targetTimeZone: timeZone,
-      sourceTimeZone,
       is12HoursSystem,
     });
 
@@ -241,7 +235,6 @@ const TimeSlot: React.FC<TimeSlotProps> = ({ dateFrom, dateTo, is12HoursSystem }
             date={dateFrom}
             timeZone={timeZone}
             is12HoursSystem={is12HoursSystem}
-            service={service}
             showDuration={showDuration}
             showQuantity={showQuantity}
           />

--- a/src/helpers/__tests__/timeFormat.test.ts
+++ b/src/helpers/__tests__/timeFormat.test.ts
@@ -1,0 +1,61 @@
+import { convertSourceDateTimeToTargetDateTime } from "../timeFormat";
+
+const UTC_DATE = "2026-04-23T07:30:00.000Z";
+
+describe("convertSourceDateTimeToTargetDateTime", () => {
+  it("formats real-UTC input in Europe/Warsaw (CEST +02:00)", () => {
+    expect(
+      convertSourceDateTimeToTargetDateTime({
+        date: UTC_DATE,
+        targetTimeZone: "Europe/Warsaw",
+      }),
+    ).toBe("9:30");
+  });
+
+  it("formats real-UTC input in UTC itself", () => {
+    expect(
+      convertSourceDateTimeToTargetDateTime({
+        date: UTC_DATE,
+        targetTimeZone: "UTC",
+      }),
+    ).toBe("7:30");
+  });
+
+  it("formats real-UTC input in America/New_York (EDT -04:00)", () => {
+    expect(
+      convertSourceDateTimeToTargetDateTime({
+        date: UTC_DATE,
+        targetTimeZone: "America/New_York",
+      }),
+    ).toBe("3:30");
+  });
+
+  it("respects a custom date format", () => {
+    expect(
+      convertSourceDateTimeToTargetDateTime({
+        date: UTC_DATE,
+        targetTimeZone: "Europe/Warsaw",
+        dateFormat: "yyyy-MM-dd HH:mm",
+      }),
+    ).toBe("2026-04-23 09:30");
+  });
+
+  it("applies targetTimeZone consistently for a UTC ISO without fractional seconds", () => {
+    expect(
+      convertSourceDateTimeToTargetDateTime({
+        date: "2026-04-23T07:30:00Z",
+        targetTimeZone: "Europe/Warsaw",
+      }),
+    ).toBe("9:30");
+  });
+
+  it("crosses date boundary correctly when shifting to a negative-offset zone", () => {
+    expect(
+      convertSourceDateTimeToTargetDateTime({
+        date: "2026-04-23T02:00:00Z",
+        targetTimeZone: "America/New_York",
+        dateFormat: "yyyy-MM-dd HH:mm",
+      }),
+    ).toBe("2026-04-22 22:00");
+  });
+});

--- a/src/helpers/functions/getDatesValue.ts
+++ b/src/helpers/functions/getDatesValue.ts
@@ -7,7 +7,6 @@ type GetDatesValue = ({
   dateTimeFrom,
   dateTimeTo,
   targetTimeZone,
-  sourceTimeZone,
   locale,
   is12HoursSystem,
 }: {
@@ -15,34 +14,25 @@ type GetDatesValue = ({
   dateTimeFrom: string;
   dateTimeTo: string;
   targetTimeZone: string;
-  sourceTimeZone: string;
   locale: Locale;
   is12HoursSystem: boolean;
 }) => string;
 
-const getDaysDatesValue: GetDatesValue = ({
-  dateTimeFrom,
-  targetTimeZone,
-  sourceTimeZone,
-  locale,
-  is12HoursSystem,
-}) => {
+const getDaysDatesValue: GetDatesValue = ({ dateTimeFrom, targetTimeZone, locale, is12HoursSystem }) => {
   const dateFormat = is12HoursSystem ? "iiii dd MMM yyyy, h:mm a" : "iiii dd MMM yyyy, H:mm";
 
   return convertSourceDateTimeToTargetDateTime({
     date: dateTimeFrom,
     targetTimeZone,
-    sourceTimeZone,
     dateFormat,
     locale,
   });
 };
 
-const getCalendarDatesValue: GetDatesValue = ({ dateTimeFrom, dateTimeTo, targetTimeZone, sourceTimeZone, locale }) => {
+const getCalendarDatesValue: GetDatesValue = ({ dateTimeFrom, dateTimeTo, targetTimeZone, locale }) => {
   const dateFromWithTimezone = convertSourceDateTimeToTargetDateTime({
     date: dateTimeFrom,
     targetTimeZone,
-    sourceTimeZone,
     dateFormat: "iii dd MMM yyyy",
     locale,
   });
@@ -50,18 +40,15 @@ const getCalendarDatesValue: GetDatesValue = ({ dateTimeFrom, dateTimeTo, target
   const dateToWithTimezone = convertSourceDateTimeToTargetDateTime({
     date: dateTimeTo,
     targetTimeZone,
-    sourceTimeZone,
     dateFormat: "iii dd MMM yyyy",
     locale,
   });
 
-  const hasSameDay = dateFromWithTimezone === dateToWithTimezone;
-
-  if (hasSameDay) {
-    return `${dateFromWithTimezone}`;
-  } else {
-    return `${dateFromWithTimezone} - ${dateToWithTimezone}`;
+  if (dateFromWithTimezone === dateToWithTimezone) {
+    return dateFromWithTimezone;
   }
+
+  return `${dateFromWithTimezone} - ${dateToWithTimezone}`;
 };
 
 const getEventDatesValue: GetDatesValue = ({
@@ -69,7 +56,6 @@ const getEventDatesValue: GetDatesValue = ({
   dateTimeFrom,
   dateTimeTo,
   targetTimeZone,
-  sourceTimeZone,
   locale,
   is12HoursSystem,
 }) => {
@@ -79,7 +65,6 @@ const getEventDatesValue: GetDatesValue = ({
   const dateFromWithTimezone = convertSourceDateTimeToTargetDateTime({
     date: dateTimeFrom,
     targetTimeZone,
-    sourceTimeZone,
     dateFormat: "iii dd MMM yyyy",
     locale,
   });
@@ -87,7 +72,6 @@ const getEventDatesValue: GetDatesValue = ({
   const dateToWithTimezone = convertSourceDateTimeToTargetDateTime({
     date: dateTimeTo,
     targetTimeZone,
-    sourceTimeZone,
     dateFormat: "iii dd MMM yyyy",
     locale,
   });
@@ -95,7 +79,6 @@ const getEventDatesValue: GetDatesValue = ({
   const timeFromWithTimezone = convertSourceDateTimeToTargetDateTime({
     date: dateTimeFrom,
     targetTimeZone,
-    sourceTimeZone,
     dateFormat: hourFormat,
     locale,
   });
@@ -103,7 +86,6 @@ const getEventDatesValue: GetDatesValue = ({
   const timeToWithTimezone = convertSourceDateTimeToTargetDateTime({
     date: dateTimeTo,
     targetTimeZone,
-    sourceTimeZone,
     dateFormat: hourFormat,
     locale,
   });
@@ -112,42 +94,27 @@ const getEventDatesValue: GetDatesValue = ({
 
   if (hasSameDay && showTime) {
     return `${dateFromWithTimezone}, ${timeFromWithTimezone} - ${timeToWithTimezone}`;
-  } else if (hasSameDay && !showTime) {
+  }
+  if (hasSameDay) {
     return `${dateFromWithTimezone}, ${timeFromWithTimezone}`;
-  } else if (!hasSameDay && !showTime) {
+  }
+  if (!showTime) {
     return `${dateFromWithTimezone} - ${dateToWithTimezone}`;
   }
 
   return `${dateFromWithTimezone}, ${timeFromWithTimezone} - ${dateToWithTimezone}, ${timeToWithTimezone}`;
 };
 
-export const getDatesValue: GetDatesValue = ({
-  service,
-  dateTimeFrom,
-  dateTimeTo,
-  targetTimeZone,
-  sourceTimeZone,
-  locale,
-  is12HoursSystem,
-}) => {
-  const serviceType = service?.viewConfig.displayType;
-  const sharedParams = {
-    service,
-    dateTimeFrom,
-    dateTimeTo,
-    targetTimeZone,
-    sourceTimeZone,
-    locale,
-    is12HoursSystem,
-  };
-
-  if (serviceType === BOOKING_FORM_TYPES.DAYS) {
-    return getDaysDatesValue(sharedParams);
-  } else if (serviceType === BOOKING_FORM_TYPES.CALENDAR) {
-    return getCalendarDatesValue(sharedParams);
-  } else if (serviceType === BOOKING_FORM_TYPES.LIST || serviceType === BOOKING_FORM_TYPES.MULTILIST) {
-    return getEventDatesValue(sharedParams);
+export const getDatesValue: GetDatesValue = (params) => {
+  switch (params.service?.viewConfig.displayType) {
+    case BOOKING_FORM_TYPES.DAYS:
+      return getDaysDatesValue(params);
+    case BOOKING_FORM_TYPES.CALENDAR:
+      return getCalendarDatesValue(params);
+    case BOOKING_FORM_TYPES.LIST:
+    case BOOKING_FORM_TYPES.MULTILIST:
+      return getEventDatesValue(params);
+    default:
+      return "";
   }
-
-  return "";
 };

--- a/src/helpers/timeFormat.tsx
+++ b/src/helpers/timeFormat.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { Locale, parseISO } from "date-fns";
-import { formatInTimeZone, toZonedTime } from "date-fns-tz";
+import { formatInTimeZone } from "date-fns-tz";
 import { stripTimezoneFromISO } from "helpers/functions";
 import styled from "styled-components";
 
@@ -8,30 +8,20 @@ export function getDateInTimezone(isoDate: string): Date {
   return parseISO(stripTimezoneFromISO(isoDate));
 }
 
-export function formatInTimezone(isoDate: string, dateFormat: string): string {
-  return formatInTimeZone(getDateInTimezone(isoDate), "UTC", dateFormat);
-}
-
 interface ConvertDateTimeParams {
   date: string;
-  sourceTimeZone: string;
   targetTimeZone: string;
+  dateFormat?: string;
   locale?: Locale;
-}
-
-function toTargetDate(date: string, targetTimeZone: string): Date {
-  return toZonedTime(new Date(date), targetTimeZone);
 }
 
 export function convertSourceDateTimeToTargetDateTime({
   date,
   targetTimeZone,
-  dateFormat,
+  dateFormat = "H:mm",
   locale,
-}: ConvertDateTimeParams & { dateFormat?: string }): string {
-  const targetDate = toTargetDate(date, targetTimeZone);
-
-  return formatInTimeZone(targetDate, targetTimeZone, dateFormat ?? "H:mm", { locale });
+}: ConvertDateTimeParams): string {
+  return formatInTimeZone(new Date(date), targetTimeZone, dateFormat, { locale });
 }
 
 const Wrapper = styled.span`
@@ -47,18 +37,26 @@ const Wrapper = styled.span`
   }
 `;
 
+interface ConvertDateTimeWithHoursSystemParams {
+  date: string;
+  targetTimeZone: string;
+  locale?: Locale;
+  is12HoursSystem?: boolean;
+}
+
 export function convertSourceDateTimeToTargetDateTimeWithHoursSystem({
   date,
   targetTimeZone,
   locale,
   is12HoursSystem,
-}: ConvertDateTimeParams & { is12HoursSystem?: boolean }): React.JSX.Element {
-  const targetDate = toTargetDate(date, targetTimeZone);
+}: ConvertDateTimeWithHoursSystemParams): React.JSX.Element {
+  const utcDate = new Date(date);
+  const timeFormat = is12HoursSystem ? "h:mm" : "H:mm";
 
   return (
     <Wrapper>
-      {formatInTimeZone(targetDate, targetTimeZone, is12HoursSystem ? "h:mm" : "H:mm", { locale })}
-      {is12HoursSystem && <small>{formatInTimeZone(targetDate, targetTimeZone, "a", { locale })}</small>}
+      {formatInTimeZone(utcDate, targetTimeZone, timeFormat, { locale })}
+      {is12HoursSystem && <small>{formatInTimeZone(utcDate, targetTimeZone, "a", { locale })}</small>}
     </Wrapper>
   );
 }


### PR DESCRIPTION
convertSourceDateTimeToTargetDateTime combined toZonedTime and formatInTimeZone on the same target tz, which double-applied the offset and shifted displayed times by ~2h when the widget's target timezone differed from the browser timezone. Simplify to a single formatInTimeZone(new Date(date), targetTimeZone, fmt) call.

Also drop the dead sourceTimeZone parameter from the helpers and all call sites (the API returns real UTC; only the target timezone is required for display).

Add regression tests covering Warsaw / UTC / New_York and widen the jest transform to tsx so the helper can be imported from tests.